### PR TITLE
Return faild status if cannt find deploy hash

### DIFF
--- a/api/services/CasperServices.js
+++ b/api/services/CasperServices.js
@@ -93,8 +93,12 @@ class CasperServices {
 		const hashes = Array.isArray(deployHash) ? deployHash : [deployHash];
 		const deploys = await Promise.all(
 			hashes.map(async (hash) => {
-				const deployJson = await this.getDeployResultJson(hash);
-				return deployJson;
+				try {
+					const deployJson = await this.getDeployResultJson(hash);
+					return deployJson;
+				} catch (error) {
+					return { deploy: { hash } };
+				}
 			}),
 		);
 
@@ -113,7 +117,9 @@ class CasperServices {
 					const { execution_results, deploy } = result;
 					return {
 						hash: deploy.hash,
-						status: !execution_results.length
+						status: !execution_results
+							? 'fail'
+							: !execution_results.length
 							? 'pending'
 							: execution_results.some((rs) => rs.result.Failure)
 							? 'fail'

--- a/api/services/CasperServices.js
+++ b/api/services/CasperServices.js
@@ -117,13 +117,12 @@ class CasperServices {
 					const { execution_results, deploy } = result;
 					return {
 						hash: deploy.hash,
-						status: !execution_results
-							? 'fail'
-							: !execution_results.length
-							? 'pending'
-							: execution_results.some((rs) => rs.result.Failure)
-							? 'fail'
-							: 'success',
+						status:
+							!execution_results || !execution_results.length
+								? 'pending'
+								: execution_results.some((rs) => rs.result.Failure)
+								? 'fail'
+								: 'success',
 					};
 			  })
 			: [];

--- a/api/services/CasperServices.test.js
+++ b/api/services/CasperServices.test.js
@@ -118,6 +118,14 @@ describe('getDeploysResult', () => {
 		expect(spyOn).toHaveBeenCalled();
 		expect(value).toEqual(['returnValue']);
 	});
+	test('Should return deploy obj with hash if have exception', async () => {
+		const spyOn = jest.spyOn(casperServices, 'getDeployResultJson');
+		spyOn.mockImplementation(() => {
+			throw 'error';
+		});
+		const value = await casperServices.getDeploysResult('test');
+		expect(value).toEqual([{ deploy: { hash: 'test' } }]);
+	});
 });
 
 describe('getDeploysStatus', () => {
@@ -127,6 +135,12 @@ describe('getDeploysStatus', () => {
 		const value = await casperServices.getDeploysStatus('testhash');
 		expect(spyOn).toHaveBeenCalled();
 		expect(value).toEqual([{ hash: 'testhash', status: 'pending' }]);
+	});
+	test('Should return deploy with fail status', async () => {
+		spyOn.mockReturnValue([{ deploy: { hash: 'testhash' } }]);
+		const value = await casperServices.getDeploysStatus('testhash');
+		expect(spyOn).toHaveBeenCalled();
+		expect(value).toEqual([{ hash: 'testhash', status: 'fail' }]);
 	});
 	test('Should return deploy with fail status', async () => {
 		spyOn.mockReturnValue([{ execution_results: [{ result: { Failure: {} } }], deploy: { hash: 'testhash' } }]);

--- a/api/services/CasperServices.test.js
+++ b/api/services/CasperServices.test.js
@@ -135,13 +135,13 @@ describe('getDeploysStatus', () => {
 		const value = await casperServices.getDeploysStatus('testhash');
 		expect(spyOn).toHaveBeenCalled();
 		expect(value).toEqual([{ hash: 'testhash', status: 'pending' }]);
-	});
-	test('Should return deploy with fail status', async () => {
+
 		spyOn.mockReturnValue([{ deploy: { hash: 'testhash' } }]);
-		const value = await casperServices.getDeploysStatus('testhash');
+		const deploy = await casperServices.getDeploysStatus('testhash');
 		expect(spyOn).toHaveBeenCalled();
-		expect(value).toEqual([{ hash: 'testhash', status: 'fail' }]);
+		expect(deploy).toEqual([{ hash: 'testhash', status: 'pending' }]);
 	});
+
 	test('Should return deploy with fail status', async () => {
 		spyOn.mockReturnValue([{ execution_results: [{ result: { Failure: {} } }], deploy: { hash: 'testhash' } }]);
 		const value = await casperServices.getDeploysStatus('testhash');

--- a/api/services/NFTServices.test.js
+++ b/api/services/NFTServices.test.js
@@ -157,14 +157,14 @@ describe('getNFTInfo', () => {
 			},
 			{
 				contractAddress: 'F4a75b1a0c1858bc4883165441107e0d23756E4ebdbD558918aD39231f1C7728',
-				metadata: false,
+				metadata: [],
 				name: 'CasperDash',
 				symbol: 'CDAS',
 				tokenId: 'token1',
 			},
 			{
 				contractAddress: 'F4a75b1a0c1858bc4883165441107e0d23756E4ebdbD558918aD39231f1C7728',
-				metadata: false,
+				metadata: [],
 				name: 'CasperDash',
 				symbol: 'CDAS',
 				tokenId: 'token2',


### PR DESCRIPTION
Fixed issue that API return error if a hash got exception, should return fail status instead.